### PR TITLE
Render abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/*
 !/.idea/codeStyles
+!/.idea/dictionaries
 !/.idea/runConfigurations
 /.gradle/
 

--- a/.idea/dictionaries/fried.xml
+++ b/.idea/dictionaries/fried.xml
@@ -1,0 +1,8 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="fried">
+    <words>
+      <w>avalonia</w>
+      <w>xaml</w>
+    </words>
+  </dictionary>
+</component>

--- a/src/rider/main/kotlin/idea/editor/AvaloniaBsonPreviewEditor.kt
+++ b/src/rider/main/kotlin/idea/editor/AvaloniaBsonPreviewEditor.kt
@@ -11,7 +11,7 @@ import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import me.fornever.avaloniarider.previewer.AvaloniaPreviewerSessionController
 import java.beans.PropertyChangeListener
 
-class AvaloniaPreviewEditor(
+class AvaloniaBsonPreviewEditor(
     project: Project,
     private val currentFile: VirtualFile
 ) : UserDataHolderBase(), FileEditor {

--- a/src/rider/main/kotlin/idea/editor/AvaloniaPreviewEditorComponent.kt
+++ b/src/rider/main/kotlin/idea/editor/AvaloniaPreviewEditorComponent.kt
@@ -33,7 +33,7 @@ class AvaloniaPreviewEditorComponent(lifetime: Lifetime, controller: AvaloniaPre
         // TODO[F]: Handle controller.status and controller.errorMessage (#41)
     }
 
-    fun drawFrame(frame: FrameMessage) {
+    private fun drawFrame(frame: FrameMessage) {
         application.assertIsDispatchThread()
 
         val image = UIUtil.createImage(this, frame.width, frame.height, BufferedImage.TYPE_INT_RGB)

--- a/src/rider/main/kotlin/idea/editor/AvaloniaPreviewEditorProvider.kt
+++ b/src/rider/main/kotlin/idea/editor/AvaloniaPreviewEditorProvider.kt
@@ -15,6 +15,7 @@ class AvaloniaPreviewEditorProvider : FileEditorProvider, DumbAware {
 
     override fun createEditor(project: Project, file: VirtualFile): FileEditor {
         val textEditor = TextEditorProvider.getInstance().createEditor(project, file) as TextEditor
-        return TextEditorWithPreview(textEditor, AvaloniaPreviewEditor(project, file))
+        val previewerEditor = AvaloniaPreviewEditor(project, file)
+        return TextEditorWithPreview(textEditor, previewerEditor)
     }
 }

--- a/src/rider/main/kotlin/idea/editor/AvaloniaPreviewEditorProvider.kt
+++ b/src/rider/main/kotlin/idea/editor/AvaloniaPreviewEditorProvider.kt
@@ -15,7 +15,7 @@ class AvaloniaPreviewEditorProvider : FileEditorProvider, DumbAware {
 
     override fun createEditor(project: Project, file: VirtualFile): FileEditor {
         val textEditor = TextEditorProvider.getInstance().createEditor(project, file) as TextEditor
-        val previewerEditor = AvaloniaPreviewEditor(project, file)
+        val previewerEditor = AvaloniaBsonPreviewEditor(project, file)
         return TextEditorWithPreview(textEditor, previewerEditor)
     }
 }


### PR DESCRIPTION
Closes #25.

I've decided that `AvaloniaPreviewEditor` is already a required abstraction. Small naming and stylistic changes, and here it is!