### PR TITLE
Fix #60: ignore fully transparent frames

### DIFF
--- a/src/rider/main/kotlin/idea/editor/BitmapPreviewEditorComponent.kt
+++ b/src/rider/main/kotlin/idea/editor/BitmapPreviewEditorComponent.kt
@@ -7,6 +7,7 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import me.fornever.avaloniarider.controlmessages.FrameMessage
 import me.fornever.avaloniarider.idea.concurrency.adviseOnUiThread
 import me.fornever.avaloniarider.previewer.AvaloniaPreviewerSessionController
+import me.fornever.avaloniarider.previewer.nonTransparent
 import me.fornever.avaloniarider.previewer.renderFrame
 import java.awt.BorderLayout
 import java.awt.image.BufferedImage
@@ -26,7 +27,8 @@ class BitmapPreviewEditorComponent(lifetime: Lifetime, controller: AvaloniaPrevi
         }
 
         controller.frame.adviseOnUiThread(lifetime) { frame ->
-            drawFrame(frame)
+            if (nonTransparent(frame)) // TODO[F]: Remove after fix of https://github.com/AvaloniaUI/Avalonia/issues/4264
+                drawFrame(frame)
             controller.acknowledgeFrame(frame)
         }
 

--- a/src/rider/main/kotlin/previewer/Graphics.kt
+++ b/src/rider/main/kotlin/previewer/Graphics.kt
@@ -4,6 +4,10 @@ import me.fornever.avaloniarider.controlmessages.FrameMessage
 import java.awt.Color
 import java.awt.image.BufferedImage
 
+fun nonTransparent(frame: FrameMessage): Boolean {
+    return frame.data.any { it != 0.toByte() }
+}
+
 private fun fromByte(b: Byte): Int = b.toInt() and 0xFF
 
 // TODO[F]: This is very suboptimal (#40)


### PR DESCRIPTION
They usually come due to bug in Avalonia (see https://github.com/AvaloniaUI/Avalonia/issues/4264), so we shouldn't ever render them.