### PR TITLE
Fix JavaFX unloading issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,6 @@ instance of Rider (set the required version via `build.gradle`).
 $ ./gradlew runIde
 ```
 
-⚠ First time after starting the IDE, you'll have to go to **Settings →
-Plugins** and install the plugin **JavaFX Runtime for Plugins**. Otherwise, the
-AvaloniaRider plugin won't work. It is a restriction to be solved in scope of
-the issue #74.
-
 Development
 -----------
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ intellij {
     type = 'RD'
     version = "$sdkVersion"
     downloadSources = false
+    plugins 'com.intellij.javafx:1.0.3'
 }
 
 runIde {

--- a/src/rider/main/kotlin/idea/JavaFxPlatformInterop.kt
+++ b/src/rider/main/kotlin/idea/JavaFxPlatformInterop.kt
@@ -1,0 +1,18 @@
+package me.fornever.avaloniarider.idea
+
+import com.intellij.openapi.components.Service
+import com.jetbrains.rd.platform.util.application
+import javafx.application.Platform
+
+// TODO[F]: Drop this class after implementation of #74
+@Service
+class JavaFxPlatformInterop {
+    companion object {
+        fun getInstance() = application.getService(JavaFxPlatformInterop::class.java)
+        fun initialize() = getInstance().initialize()
+    }
+
+    fun initialize() {
+        Platform.setImplicitExit(false)
+    }
+}

--- a/src/rider/main/kotlin/idea/editor/HtmlPreviewEditorComponent.kt
+++ b/src/rider/main/kotlin/idea/editor/HtmlPreviewEditorComponent.kt
@@ -5,6 +5,7 @@ import javafx.application.Platform
 import javafx.embed.swing.JFXPanel
 import javafx.scene.Scene
 import javafx.scene.web.WebView
+import me.fornever.avaloniarider.idea.JavaFxPlatformInterop
 import me.fornever.avaloniarider.previewer.AvaloniaPreviewerSessionController
 import java.awt.FlowLayout
 import javax.swing.JPanel
@@ -13,6 +14,7 @@ class HtmlPreviewEditorComponent(lifetime: Lifetime, controller: AvaloniaPreview
 
     private lateinit var webView: WebView
     init {
+        JavaFxPlatformInterop.initialize()
         layout = FlowLayout()
 
         add(JFXPanel().apply {


### PR DESCRIPTION
It turns out JavaFX really loves to unload itself from the process. Usually it do this after its last window (in our case, a browser control) is closed/terminated.

This behavior us unwanted in case when we could want to load new controls in future, so we have to suppress this behavior for now.