### PR TITLE
Fix a problem with Kotlin libraries being packed altogether with the plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
This will fix the plugin load error due to invalid `kotlin-reflection` being loaded.