### PR TITLE
#55: allow to use current run configuration instead of containing project

### DIFF
--- a/src/rider/main/kotlin/idea/settings/AvaloniaSettings.kt
+++ b/src/rider/main/kotlin/idea/settings/AvaloniaSettings.kt
@@ -11,8 +11,14 @@ enum class AvaloniaPreviewerMethod {
     Html
 }
 
+enum class ExecutableProjectSelectionMode {
+    Automatic,
+    RunConfiguration
+}
+
 class AvaloniaSettingsState : BaseState() {
     var previewerMethod by enum(AvaloniaPreviewerMethod.AvaloniaRemote)
+    var projectSelectionMode by enum(ExecutableProjectSelectionMode.Automatic)
 }
 
 @State(name = "Avalonia")
@@ -24,4 +30,7 @@ class AvaloniaSettings : SimplePersistentStateComponent<AvaloniaSettingsState>(A
 
     val previewerTransportType: AvaloniaPreviewerMethod
         get() = state.previewerMethod
+
+    val projectSelectionMode: ExecutableProjectSelectionMode
+        get() = state.projectSelectionMode
 }

--- a/src/rider/main/kotlin/idea/settings/AvaloniaSettingsComponent.kt
+++ b/src/rider/main/kotlin/idea/settings/AvaloniaSettingsComponent.kt
@@ -2,7 +2,8 @@ package me.fornever.avaloniarider.idea.settings
 
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.components.JBLabel
-import java.awt.FlowLayout
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
 import javax.swing.JPanel
 
 class AvaloniaSettingsComponent(state: AvaloniaSettingsState) : JPanel() {
@@ -17,20 +18,33 @@ class AvaloniaSettingsComponent(state: AvaloniaSettingsState) : JPanel() {
             previewerTransportTypeSelector.selectedItem = value
         }
 
+    private val projectSelectionModeSelector = ComboBox(ExecutableProjectSelectionMode.values())
+    private var projectSelectionMode: ExecutableProjectSelectionMode
+        get() = projectSelectionModeSelector.selectedItem as ExecutableProjectSelectionMode
+        set(value) {
+            projectSelectionModeSelector.selectedItem = value
+        }
+
     init {
         previewerMethod = initialState.previewerMethod
+        projectSelectionMode = initialState.projectSelectionMode
 
-        layout = FlowLayout(FlowLayout.LEFT)
-        add(JBLabel("Previewer Method:"))
-        add(previewerTransportTypeSelector)
+        layout = GridBagLayout()
+        add(JBLabel("Previewer Method:"), GridBagConstraints().apply { anchor = GridBagConstraints.LINE_START })
+        add(previewerTransportTypeSelector, GridBagConstraints().apply { gridx = 1 })
+
+        add(JBLabel("Project Selection Mode:"), GridBagConstraints().apply { gridy = 1 })
+        add(projectSelectionModeSelector, GridBagConstraints().apply { gridx = 1; gridy = 1 })
     }
 
     var currentState: AvaloniaSettingsState
         get() = AvaloniaSettingsState().apply {
             previewerMethod = this@AvaloniaSettingsComponent.previewerMethod
+            projectSelectionMode = this@AvaloniaSettingsComponent.projectSelectionMode
         }
         set(value) {
             previewerMethod = value.previewerMethod
+            projectSelectionMode = value.projectSelectionMode
         }
 
     val isModified: Boolean


### PR DESCRIPTION
This adds a new setting, **Project Selection Mode**, and allows the users to choose to use current project selected from the run configuration instead of the default, "automatic" mode (which, for now, just picks the project containing the XAML file).

Still very rough, but should unblock people who works on DLLs with XAML files.

To enable this, open **Settings** and change the setting to **RunConfiguration**:
![image](https://user-images.githubusercontent.com/92793/106925059-4cdd3500-6742-11eb-946d-66a5521a9437.png)
