### PR TITLE
Disable caches on CI

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,32 +7,14 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-18.04
-    env:
-      NUGET_PACKAGES: ${{ github.workspace }}/.github/nuget-packages
-      GRADLE_USER_HOME: ${{ github.workspace }}/.github/gradle
     steps:
       - uses: actions/checkout@v2
 
       # RdGen
-      - name: Gradle JVM Cache
-        uses: actions/cache@v1.1.0
-        with:
-          path: build/gradle-jvm
-          key: ${{ runner.os }}.gradle-jvm.${{ hashFiles('**/*.gradle') }}+${{ hashFiles('gradle*') }}
-      - name: Gradle Wrapper Cache
-        uses: actions/cache@v1.1.0
-        with:
-          path: ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}.gradle-wrapper.${{ hashFiles('gradle/**') }}
       - name: RdGen
         run: ./gradlew rdgen
 
       # Backend
-      - name: NuGet Cache
-        uses: actions/cache@v1.1.0
-        with:
-          path: ${{ env.NUGET_PACKAGES }}
-          key: ${{ runner.os }}.nuget.${{ hashFiles('src/dotnet/**/*.csproj') }}+${{ hashFiles('src/dotnet/**/*.props') }}
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1.7.2
         with:
@@ -50,7 +32,3 @@ jobs:
         run: scripts/Publish-Distribution.ps1 -Channel dev -AuthToken $env:JETBRAINS_MARKETPLACE_TOKEN
         env:
           JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
-
-      # Finalize
-      - name: Stop Gradle Daemon # to collect Gradle cache
-        run: ./gradlew --stop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,37 +13,14 @@ jobs:
     strategy:
       matrix:
         image: [macos-10.15, ubuntu-18.04, windows-2019]
-    env:
-      NUGET_PACKAGES: ${{ github.workspace }}/.github/nuget-packages
-      GRADLE_USER_HOME: ${{ github.workspace }}/.github/gradle
     steps:
       - uses: actions/checkout@v2
 
       # RdGen
-      - name: Gradle JVM Cache
-        uses: actions/cache@v1.1.0
-        with:
-          path: build/gradle-jvm
-          key: ${{ runner.os }}.gradle-jvm.${{ hashFiles('**/*.gradle') }}+${{ hashFiles('gradle*') }}
-      - name: Gradle Wrapper Cache
-        uses: actions/cache@v1.1.0
-        with:
-          path: ${{ env.GRADLE_USER_HOME }}/wrapper
-          key: ${{ runner.os }}.gradle-wrapper.${{ hashFiles('gradle/**') }}
-      - name: Gradle Cache
-        uses: actions/cache@v1.1.0
-        with:
-          path: ${{ env.GRADLE_USER_HOME }}/caches/modules-2
-          key: ${{ runner.os }}.gradle.${{ hashFiles('**/*.gradle') }}
       - name: RdGen
         run: ./gradlew rdgen
 
       # Backend
-      - name: NuGet Cache
-        uses: actions/cache@v1.1.0
-        with:
-          path: ${{ env.NUGET_PACKAGES }}
-          key: ${{ runner.os }}.nuget.${{ hashFiles('src/dotnet/**/*.csproj') }}+${{ hashFiles('src/dotnet/**/*.props') }}
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1.7.2
         with:
@@ -83,7 +60,3 @@ jobs:
         with:
           name: avaloniarider-${{ env.AVALONIA_RIDER_VERSION }}
           path: build/distributions/unpacked
-
-      # Finalize
-      - name: Stop Gradle Daemon # to collect Gradle cache
-        run: ./gradlew --stop

--- a/src/test/kotlin/testcases/PreviewTests.kt
+++ b/src/test/kotlin/testcases/PreviewTests.kt
@@ -20,6 +20,7 @@ import java.time.Duration
 class PreviewTests : BaseTestWithSolution() {
     override fun getSolutionDirectoryName() = "AvaloniaMvvm"
     override val restoreNuGetPackages = true
+    override val backendLoadedTimeout: Duration = Duration.ofMinutes(2L)
 
     private val mainWindowFile
         get() = getVirtualFileFromPath("Views/MainWindow.xaml", activeSolutionDirectory)


### PR DESCRIPTION
Unfortunately, Rider artifacts are so big they don't fit the CI caches, and just slow everything down (while the poor CI is trying to upload the caches, that get discarded afterwards).