### PR TITLE
CI: add schedule and update some versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -16,9 +16,9 @@ jobs:
 
       # Backend
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.101'
+          dotnet-version: '3.1.x'
       - name: Build Backend
         run: dotnet build -c Release
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ jobs:
     strategy:
       matrix:
         image: [macos-10.15, ubuntu-20.04, windows-2019]
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Main
 on:
   push:
     branches:
@@ -6,13 +6,15 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   main:
     runs-on: ${{ matrix.image }}
     strategy:
       matrix:
-        image: [macos-10.15, ubuntu-18.04, windows-2019]
+        image: [macos-10.15, ubuntu-20.04, windows-2019]
     steps:
       - uses: actions/checkout@v2
 
@@ -22,9 +24,9 @@ jobs:
 
       # Backend
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.101'
+          dotnet-version: '3.1.x'
       - name: Build Backend
         run: dotnet build -c Release
 
@@ -35,27 +37,27 @@ jobs:
           LOCAL_ENV_RUN: true
           NO_FS_ROOTS_ACCESS_CHECK: true
       - name: Upload Test Results
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}.test-results
           path: build/reports/tests
 
       # Distribution
       - name: Build Distribution
-        if: matrix.image == 'ubuntu-18.04'
+        if: matrix.image == 'ubuntu-20.04'
         run: ./gradlew -PBuildConfiguration=Release -PbuildNumber=${{ github.run_id }} buildPlugin
       - name: Determine Version
-        if: matrix.image == 'ubuntu-18.04'
+        if: matrix.image == 'ubuntu-20.04'
         shell: pwsh
         run: |
           $version = ./scripts/Get-Version.ps1
           "AVALONIA_RIDER_VERSION=$version" | Out-File $env:GITHUB_ENV
       - name: Unpack Distribution # for the purpose of uploading
-        if: matrix.image == 'ubuntu-18.04'
+        if: matrix.image == 'ubuntu-20.04'
         shell: pwsh
         run: scripts/Unpack-Distribution.ps1
       - name: Upload Distribution
-        if: matrix.image == 'ubuntu-18.04'
+        if: matrix.image == 'ubuntu-20.04'
         uses: actions/upload-artifact@v2
         with:
           name: avaloniarider-${{ env.AVALONIA_RIDER_VERSION }}


### PR DESCRIPTION
Since I've put builds on the schedule, we now may use more volatile versions of the GitHub actions and .NET Core SDK: if anything break, I'll be notified in time.