### PR TITLE
Dependencies: update to Rider 2021.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 ext {
     pluginVersionBase = '1.0.0'
-    sdkVersion = '2021.1-SNAPSHOT'
+    sdkVersion = '2021.1.0'
     rdLibDirectory = {
         new File(intellij.ideaDependency.classes, "lib/rd")
     }

--- a/src/dotnet/Versions.props
+++ b/src/dotnet/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SdkVersion>2021.1.0-eap05</SdkVersion>
+    <SdkVersion>2021.1.0</SdkVersion>
     <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
     <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
   </PropertyGroup>


### PR DESCRIPTION
Closes #129.

The issue was that the recent plugin versions were released for Rider EAP which has a higher version number than the stable release.