### PR TITLE
Collect usage statistics

### DIFF
--- a/.idea/runConfigurations/_template__of_Gradle.xml
+++ b/.idea/runConfigurations/_template__of_Gradle.xml
@@ -17,6 +17,7 @@
       <option name="taskNames">
         <list />
       </option>
+      <option name="tasksAndArguments" value="" />
       <option name="vmOptions" value="" />
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,8 @@ intellij {
 }
 
 runIde {
+    // For statistics:
+//    jvmArgs '-Xmx1500m', '-Didea.is.internal=true', '-Dfus.internal.test.mode=true'
     jvmArgs '-Xmx1500m'
 }
 

--- a/src/rider/main/kotlin/statistics/PreviewerUsageLogger.kt
+++ b/src/rider/main/kotlin/statistics/PreviewerUsageLogger.kt
@@ -1,0 +1,29 @@
+package me.fornever.avaloniarider.statistics
+
+import com.intellij.internal.statistic.eventLog.EventLogGroup
+import com.intellij.internal.statistic.service.fus.collectors.CounterUsagesCollector
+import com.intellij.openapi.project.Project
+
+@Suppress("UnstableApiUsage")
+class PreviewerUsageLogger : CounterUsagesCollector() {
+    companion object {
+        private val GROUP = EventLogGroup("avalonia.previewer", 1)
+        private val PREVIEW_SUCCESS = GROUP.registerEvent("preview.success")
+        private val PREVIEW_FAILURE = GROUP.registerEvent("preview.failure")
+        private val PREVIEW_CRITICAL = GROUP.registerEvent("preview.critical_failure")
+
+        fun logPreviewSuccess(project: Project) {
+            PREVIEW_SUCCESS.log(project)
+        }
+
+        fun logPreviewError(project: Project) {
+            PREVIEW_FAILURE.log(project)
+        }
+
+        fun logPreviewCriticalFailure(project: Project) {
+            PREVIEW_CRITICAL.log(project)
+        }
+    }
+
+    override fun getGroup() = GROUP
+}

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -31,5 +31,7 @@
                             os="unix"/>
 
         <rider.xaml.preview.editor implementation="me.fornever.avaloniarider.idea.editor.AvaloniaPreviewerXamlEditorExtension"/>
+
+        <statistics.counterUsagesCollector implementationClass="me.fornever.avaloniarider.statistics.PreviewerUsageLogger" />
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
The usage statistics depend on the IntelliJ data collection infrastructure, and adheres to the general data collection policy. Also, only count of successful and failed previewer starts gets collected, and no user data at all.