### PR TITLE
Infra: migrate to a common Rider SDK

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # RdGen
-      - name: RdGen
-        run: ./gradlew rdgen
+      # Common preparation
+      - name: Prepare build
+        run: ./gradlew prepare
 
       # Backend
       - name: Set up .NET SDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # RdGen
-      - name: RdGen
-        run: ./gradlew rdgen
+      # Common preparation
+      - name: Prepare build
+        run: ./gradlew prepare
 
       # Backend
       - name: Set up .NET SDK

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !/.idea/dictionaries
 !/.idea/runConfigurations
 /.gradle/
+/nuget.config
 
 bin/
 build/

--- a/AvaloniaRider.sln
+++ b/AvaloniaRider.sln
@@ -2,6 +2,11 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AvaloniaRider.Plugin", "src\dotnet\AvaloniaRider.Plugin\AvaloniaRider.Plugin.csproj", "{084172D1-A9C6-46D0-96AD-05C5B09A5E5D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{08837280-369F-4B0E-A34F-AA662D1188D5}"
+	ProjectSection(SolutionItems) = preProject
+		src\dotnet\Directory.Build.props = src\dotnet\Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Build
 
 ### Build
 
-To build from terminal, execute this command:
+To build the plugin, execute this shell command:
 
 ```console
 $ ./gradlew buildPlugin
@@ -89,6 +89,16 @@ frontend one (written in Kotlin). Each part requires a corresponding IDE. To
 develop a backend, it's recommended to open `AvaloniaRider.sln` with JetBrains
 Rider. To develop a frontend, it's recommended to use IntelliJ IDEA (Community
 edition should be enough).
+
+## Getting Started
+
+If you just want to start developing the plugin and don't want to build it (yet), then execute this shell command:
+
+```console
+$ ./gradlew prepare
+```
+
+This will download the initial set of dependencies necessary for the plugin development and set up Rider SDK for .NET part of the project. After that, open either the frontend part of the plugin (the directory containing `build.gradle.kts`) using IntelliJ IDEA, or the `AvaloniaRider.sln` using Rider.
 
 ## IDE Setup
 

--- a/src/dotnet/AvaloniaRider.Plugin/AvaloniaRider.Plugin.csproj
+++ b/src/dotnet/AvaloniaRider.Plugin/AvaloniaRider.Plugin.csproj
@@ -1,18 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <RootNamespace>ReSharperPlugin.AvaloniaRider</RootNamespace>
+    <RootNamespace>AvaloniaRider</RootNamespace>
     <DefineConstants>$(DefineConstants);RIDER</DefineConstants>
   </PropertyGroup>
-  
-  <Import Project="..\Versions.props" />
-  
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="$(SdkVersion)">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Wave" Version="$(WaveVersion)" />
-  </ItemGroup>
-  
+
+  <Import Project="$(JetBrainsRiderRdBackendCommonReference)" Condition="Exists('$(JetBrainsRiderRdBackendCommonReference)')" />
 </Project>

--- a/src/dotnet/AvaloniaRider.Plugin/AvaloniaRiderProjectModelHost.cs
+++ b/src/dotnet/AvaloniaRider.Plugin/AvaloniaRiderProjectModelHost.cs
@@ -13,7 +13,7 @@ using JetBrains.RdBackend.Common.Features;
 using JetBrains.ReSharper.Features.Running;
 using JetBrains.Util;
 
-namespace ReSharperPlugin.AvaloniaRider
+namespace AvaloniaRider
 {
     [SolutionComponent]
     public class AvaloniaRiderProjectModelHost

--- a/src/dotnet/AvaloniaRider.Plugin/ZoneMarker.cs
+++ b/src/dotnet/AvaloniaRider.Plugin/ZoneMarker.cs
@@ -1,11 +1,12 @@
 ﻿using JetBrains.Application.BuildScript.Application.Zones;
 using JetBrains.Platform.RdFramework;
 using JetBrains.ProjectModel;
+using JetBrains.Rider.Model;
 
-namespace ReSharperPlugin.AvaloniaRider
+namespace AvaloniaRider
 {
     [ZoneMarker]
-    public class ZoneMarker : IRequire<IProjectModelZone>, IRequire<ISinceClr4HostZone>, IRequire<IRdFrameworkZone>
+    public class ZoneMarker : IRequire<IProjectModelZone>, IRequire<ISinceClr4HostZone>, IRequire<IRdFrameworkZone>, IRequire<IRiderModelZone>
     {
     }
 }

--- a/src/dotnet/Directory.Build.props
+++ b/src/dotnet/Directory.Build.props
@@ -1,5 +1,4 @@
 <Project>
-
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -15,5 +14,11 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>TRACE;DEBUG;JET_MODE_ASSERT</DefineConstants>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\DotNetSdkPath.Generated.props" />
+
+  <PropertyGroup>
+    <JetBrainsRiderRdBackendCommonReference>$(DotNetSdkPath)\Build\PackageReference.JetBrains.Rider.RdBackend.Common.Props</JetBrainsRiderRdBackendCommonReference>
   </PropertyGroup>
 </Project>

--- a/src/dotnet/Versions.props
+++ b/src/dotnet/Versions.props
@@ -1,7 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <SdkVersion>2022.1.0-eap09</SdkVersion>
-    <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
-    <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
This will use the same Rider SDK on the frontend and on the backend of the plugin, instead of downloading a different one from NuGet. So, there will be a single place to define the SDK version, which should help.