### PR TITLE
Features/grid plus fix dpi

### DIFF
--- a/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/BitmapPreviewEditorComponent.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/BitmapPreviewEditorComponent.kt
@@ -77,7 +77,7 @@ class BitmapPreviewEditorComponent(
         mainScrollView.viewport.view = when (newStatus) {
             Status.Idle, Status.Connecting -> spinnerView.value
             Status.Working -> frameBufferView.value
-            Status.XamlError -> errorView.value
+            Status.XamlError -> frameBufferView.value
             Status.Suspended -> spinnerView.value
             Status.Terminated -> terminatedView.value
         }

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt
@@ -33,6 +33,9 @@ class PreviewImageView(
         listener.avaloniaInputEvent.advise(lifetime) { message ->
             controller.sendInputEventMessage(message)
         }
+        listener.zoomEvent.advise(lifetime) { zoomFactor ->
+            controller.setZoomFactor(zoomFactor);
+        }
         addMouseListener(listener)
         addMouseMotionListener(listener)
         addMouseWheelListener(listener)

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt
@@ -1,6 +1,11 @@
 package me.fornever.avaloniarider.idea.editor
 
+import com.intellij.ide.ui.LafManager
+import com.intellij.ide.ui.laf.UIThemeBasedLookAndFeelInfo
 import com.intellij.openapi.rd.createNestedDisposable
+import com.intellij.openapi.rd.paint2DLine
+import com.intellij.ui.paint.LinePainter2D
+import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.Alarm
 import com.intellij.util.application
 import com.intellij.util.ui.UIUtil
@@ -10,10 +15,13 @@ import me.fornever.avaloniarider.idea.settings.AvaloniaSettings
 import me.fornever.avaloniarider.previewer.AvaloniaMessageMouseListener
 import me.fornever.avaloniarider.previewer.AvaloniaPreviewerSessionController
 import me.fornever.avaloniarider.previewer.renderFrame
+import java.awt.Color
 import java.awt.Dimension
 import java.awt.Graphics
+import java.awt.Graphics2D
 import java.awt.image.BufferedImage
 import javax.swing.JComponent
+
 
 class PreviewImageView(
     lifetime: Lifetime,
@@ -45,11 +53,77 @@ class PreviewImageView(
         return buffer?.let { Dimension(it.width, it.height) } ?: super.getPreferredSize()
     }
 
+    private fun isDark (): Boolean {
+        if(UIUtil.isUnderDarcula())
+        {
+            return true;
+        }
+        else {
+            val lafManager = LafManager.getInstance()
+            val currentLafInfo = lafManager.currentLookAndFeel
+            val theme = if (currentLafInfo is UIThemeBasedLookAndFeelInfo) currentLafInfo.theme else null
+            return theme != null && theme.isDark
+        }
+    }
+
+    private fun paintGrid(g: Graphics)
+    {
+        var context = g as Graphics2D;
+
+        var thickLineColor = Color(14.0f / 255.0f, 94.0f / 255.0f, 253.0f / 255.0f, 0.3f);
+        var lineColor = Color(14.0f / 255.0f, 94.0f / 255.0f, 253.0f / 255.0f, 0.1f);
+
+        if(isDark())
+        {
+            thickLineColor = Color(11.0f / 255.0f, 94.0f / 255.0f, 253.0f / 255.0f, 0.3f);
+            lineColor = Color(11.0f / 255.0f, 94.0f / 255.0f, 253.0f / 255.0f, 0.1f);
+        }
+
+        var height = height.toDouble();
+        var width = width.toDouble();
+
+        for(i in 1 .. (this.width / 10))
+        {
+            var color = lineColor;
+
+            if(i % 10 == 0)
+            {
+                color = thickLineColor;
+            }
+
+            context.paint2DLine(i * 10.0, 0.0, i * 10.0, height, strokeType = LinePainter2D.StrokeType.CENTERED, strokeWidth = 1.0, color);
+        }
+
+        for(i in 1 .. (this.height / 10))
+        {
+            var color = lineColor;
+
+            if(i % 10 == 0)
+            {
+                color = thickLineColor;
+            }
+
+            context.paint2DLine(0.0, i * 10.0, width, i * 10.0, strokeType = LinePainter2D.StrokeType.CENTERED, strokeWidth = 1.0, color);
+        }
+    }
+
     override fun paintComponent(g: Graphics) {
         super.paintComponent(g)
 
-        g.color = UIUtil.getControlColor()
+
+        if(isDark())
+        {
+            g.color = Color(24,24,24);
+        }
+        else
+        {
+            g.color = Color(0xFF, 0xFF, 0xFF);
+        }
+
         g.fillRect(0, 0, width, height)
+
+        paintGrid(g);
+
         buffer?.let { image ->
             g.drawImage(image, shiftImageX, shiftImageY, image.width, image.height, null)
         }

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt
@@ -110,6 +110,7 @@ class PreviewImageView(
     override fun paintComponent(g: Graphics) {
         super.paintComponent(g)
 
+        var sysscale = JBUIScale.sysScale();
 
         if(isDark())
         {
@@ -125,7 +126,7 @@ class PreviewImageView(
         paintGrid(g);
 
         buffer?.let { image ->
-            g.drawImage(image, shiftImageX, shiftImageY, image.width, image.height, null)
+            g.drawImage(image, shiftImageX, shiftImageY, (image.width / sysscale).toInt(), (image.height / sysscale).toInt(), null)
         }
 
         lastFrame?.let {

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaMessageMouseListener.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaMessageMouseListener.kt
@@ -15,9 +15,14 @@ internal class AvaloniaMessageMouseListener(
     private val frameView: PreviewImageView
 ) : MouseInputAdapter() {
 
+    private var zoomFactor = 1.0;
     private val avaloniaInputEventSignal = Signal<AvaloniaInputEventMessage>()
 
     val avaloniaInputEvent: ISource<AvaloniaInputEventMessage> = avaloniaInputEventSignal
+
+    private val zoomEventSignal = Signal<Double>();
+
+    val zoomEvent: ISource<Double> = zoomEventSignal;
 
     override fun mousePressed(e: MouseEvent?) {
         e ?: return
@@ -44,6 +49,26 @@ internal class AvaloniaMessageMouseListener(
     override fun mouseWheelMoved(e: MouseWheelEvent?) {
         e ?: return
         if (e.scrollType != MouseWheelEvent.WHEEL_UNIT_SCROLL) return
+
+        if(e.isControlDown) {
+            var oldValue = zoomFactor;
+            zoomFactor += e.preciseUnitsToScroll();
+
+            if(zoomFactor > 10.0)
+            {
+                zoomFactor = 10.0;
+            }
+            else if(zoomFactor < 0.4)
+            {
+                zoomFactor = 0.4;
+            }
+
+            if(oldValue != zoomFactor) {
+                zoomEventSignal.fire(zoomFactor);
+            }
+            return;
+        }
+
         val coordinates = e.pointerPositionOrNull()?: return
         val message = ScrollEventMessage(
             e.avaloniaModifiers(),

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaMessageMouseListener.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaMessageMouseListener.kt
@@ -108,7 +108,7 @@ internal class AvaloniaMessageMouseListener(
         val isContainsY = 0 <= iconY && iconY <= (frameView.buffer?.height ?: 0)
         if (!isContainsY) return null
 
-        return iconX.toDouble() to iconY.toDouble()
+        return iconX.toDouble() / zoomFactor to iconY.toDouble() / zoomFactor
     }
 
     private fun MouseEvent.avaloniaModifiers(): Array<Int> {

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaPreviewerSessionController.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaPreviewerSessionController.kt
@@ -335,4 +335,9 @@ class AvaloniaPreviewerSessionController(
     fun sendInputEventMessage(event: AvaloniaInputEventMessage) {
         session?.sendInputEventMessage(event)
     }
+
+    fun setZoomFactor(zoomFactor: Double)
+    {
+        session?.sendDpi((96.0 * JBUIScale.sysScale()) * zoomFactor);
+    }
 }

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaPreviewerSessionController.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaPreviewerSessionController.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.rd.util.withIOBackgroundContext
 import com.intellij.openapi.rd.util.withUiContext
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.application
 import com.intellij.workspaceModel.ide.WorkspaceModel
 import com.jetbrains.rd.util.lifetime.*
@@ -198,7 +199,7 @@ class AvaloniaPreviewerSessionController(
     ).apply {
         sessionStarted.advise(lifetime) {
             sendClientSupportedPixelFormat()
-            sendDpi(96.0) // TODO[F]: Properly acquire from the UI side (#9)
+            sendDpi(96.0 * JBUIScale.sysScale())
 
             application.runReadAction {
                 val document = FileDocumentManager.getInstance().getDocument(xamlFile)!!


### PR DESCRIPTION
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/4672627/169350850-d07a4914-c949-4b5d-898c-c39b537dca89.png">

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/4672627/169350899-5c125f4e-7fc9-46ae-a6a1-818bd81b99f0.png">

- Adds grid
- Correct DPI handling
- Zooming with CTRL + Mouse wheel
- Doesn't display parsing errors over the previewer, holds the last good render. (Rider editor does a good job now of telling us what's wrong).

@ForNeVeR some of these might be implemented in kind of "hacky" way.

However I believe this is a good improvement to the bitmap based previewer. We should use it like that for now.

We can then simply concentrate on upgrading the html version and implement that one properly.


The only improvement I think can be made to the bitmap version would be to enable panning on the canvas when zooming... but I couldn't work out how to do it.

Closes #110.