### PR TITLE
AvaloniaPreviewerSessionController: fix initial DPI scaling

### DIFF
--- a/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaPreviewerSessionController.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/previewer/AvaloniaPreviewerSessionController.kt
@@ -148,7 +148,7 @@ class AvaloniaPreviewerSessionController(
 
                 // Try to guess DPI if we got called without a signal from the control. After the control tells us the
                 // right DPI, we'll apply it later.
-                val effectiveDpi = dpi ?: JBUIScale.sysScale().toDouble()
+                val effectiveDpi = dpi ?: (JBUIScale.sysScale().toDouble() * 96.0)
                 session?.sendDpi(effectiveDpi * zoomFactor)
             }
 


### PR DESCRIPTION
When debugging the Avalonia previewer, I noticed that AvaloniaRider initially sends the scaling value (in my case 1) instead of the actual DPI (96), resulting in a very small first frame. Note that this usually automatically fixes itself later when the previewer receives the correct DPI information.

This PR fixes that initial value.