### PR TITLE
CI: add a stale issue bot that will auto-close the stale waiting-for-info issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Close stale issues'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: -1
+          stale-issue-label: 'status:waiting-for-info'
+          remove-stale-when-updated: 'false'
+          days-before-close: 14
+          close-issue-message: 'This issue was closed because it has been open for 14 days, but no requested information was received. Please leave a comment if you think this is a mistake.'


### PR DESCRIPTION
It won't close the normal issues with bugs or feature requests, but only the issues we are unable to process without further information from the users, so it shouid be okay.