### PR TITLE
RIDER-115746: Revert adding DPA dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,10 +39,7 @@ dependencies {
         jetbrainsRuntime()
         instrumentationTools()
 
-        bundledPlugins(
-            "com.jetbrains.xaml.previewer",
-            "com.jetbrains.dpa" // for tests; see RIDER-115746
-        )
+        bundledPlugins("com.jetbrains.xaml.previewer")
 
         testFramework(TestFrameworkType.Bundled)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 kotlin = "1.9.22"
 rdGen = "2024.1.1"
-riderSdk = "2024.2-RC1-SNAPSHOT"
-riderSdkPreview = "2024.2-RC1-SNAPSHOT"
+riderSdk = "2024.2"
+riderSdkPreview = "2024.2"
 
 [libraries]
 bson4Jackson = "de.undercouch:bson4jackson:2.15.1"


### PR DESCRIPTION
We got backend setup fixed in the latest SDK, so we can now revert the workaround.