### PR TITLE
Add dark/light theme switch

### DIFF
--- a/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/AvaloniaPreviewEditorBase.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/AvaloniaPreviewEditorBase.kt
@@ -36,6 +36,7 @@ import me.fornever.avaloniarider.AvaloniaRiderBundle
 import me.fornever.avaloniarider.idea.editor.actions.RestartPreviewerAction
 import me.fornever.avaloniarider.idea.editor.actions.RunnableAssemblySelectorAction
 import me.fornever.avaloniarider.idea.editor.actions.TogglePreviewerLogAction
+import me.fornever.avaloniarider.idea.editor.actions.ToggleThemeAction
 import me.fornever.avaloniarider.previewer.AvaloniaPreviewerSessionController
 import me.fornever.avaloniarider.ui.bindVisible
 import java.awt.BorderLayout
@@ -181,6 +182,7 @@ abstract class AvaloniaPreviewEditorBase(
             add(assemblySelectorAction)
             add(RestartPreviewerAction(lifetime, sessionController, selectedProjectPath))
             addAll(*actions)
+            add(ToggleThemeAction(AvaloniaProjectSettings.getInstance(project)))
             add(TogglePreviewerLogAction(isLogManuallyVisible))
         }
 

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt
@@ -71,7 +71,7 @@ class PreviewImageView(
     }
 
     private fun isDarkTheme(): Boolean {
-        return !JBColor.isBright()
+        return settings.isDarkTheme
     }
 
     private fun paintGrid(g: Graphics2D) {

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/actions/ToggleThemeAction.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/actions/ToggleThemeAction.kt
@@ -1,0 +1,16 @@
+package me.fornever.avaloniarider.idea.editor.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.ToggleAction
+import me.fornever.avaloniarider.idea.settings.AvaloniaProjectSettings
+
+class ToggleThemeAction(private val projectSettings: AvaloniaProjectSettings) : ToggleAction() {
+
+    override fun isSelected(e: AnActionEvent): Boolean {
+        return projectSettings.state.isDarkTheme
+    }
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        projectSettings.state.isDarkTheme = state
+    }
+}

--- a/src/rider/main/kotlin/me/fornever/avaloniarider/idea/settings/AvaloniaProjectSettings.kt
+++ b/src/rider/main/kotlin/me/fornever/avaloniarider/idea/settings/AvaloniaProjectSettings.kt
@@ -20,6 +20,8 @@ class AvaloniaProjectSettingsState : BaseState() {
     var synchronizeWithRunConfiguration by property(false)
 
     var fpsLimit by property(0)
+
+    var isDarkTheme by property(false)
 }
 
 @State(name = "Avalonia") // TODO[#265]: Move to avalonia.xml
@@ -37,4 +39,7 @@ class AvaloniaProjectSettings : SimplePersistentStateComponent<AvaloniaProjectSe
 
     val fpsLimit: Int
         get() = state.fpsLimit
+
+    val isDarkTheme: Boolean
+        get() = state.isDarkTheme
 }


### PR DESCRIPTION
Fixes #396

Add a light/dark theme switch in the preview to switch between themes without explicitly defining the theme in design.

* **New Action Class**: Add `ToggleThemeAction` in `src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/actions/ToggleThemeAction.kt` to handle theme switching.
* **Toolbar Update**: Update `AvaloniaPreviewEditorBase` in `src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/AvaloniaPreviewEditorBase.kt` to include `ToggleThemeAction` in the toolbar.
* **Settings Update**: Modify `AvaloniaProjectSettings` in `src/rider/main/kotlin/me/fornever/avaloniarider/idea/settings/AvaloniaProjectSettings.kt` to include a new property `isDarkTheme` to store the current theme state.
* **Preview Image View Update**: Update `PreviewImageView` in `src/rider/main/kotlin/me/fornever/avaloniarider/idea/editor/PreviewImageView.kt` to use the `isDarkTheme` property from `AvaloniaProjectSettings` to determine the theme.

